### PR TITLE
add corruption category option to get_corruption_names

### DIFF
--- a/imagecorruptions/__init__.py
+++ b/imagecorruptions/__init__.py
@@ -75,5 +75,13 @@ def get_corruption_names(subset='common'):
         return [f.__name__ for f in corruption_tuple[15:]]
     elif subset == 'all':
         return [f.__name__ for f in corruption_tuple]
+    elif subset == 'noise':
+        return [f.__name__ for f in corruption_tuple[0:3]]
+    elif subset == 'blur':
+        return [f.__name__ for f in corruption_tuple[3:7]]
+    elif subset == 'weather':
+        return [f.__name__ for f in corruption_tuple[7:11]]
+    elif subset == 'digital':
+        return [f.__name__ for f in corruption_tuple[11:15]]
     else:
         raise ValueError("subset must be one of ['common', 'validation', 'all']")


### PR DESCRIPTION
Hi,

I added the corruption category flags to the `get_corruption_names` function to make it easier to specify a subset of the corruptions. The corruption categories are taken from Dan's original groupings:

<img width="862" alt="image" src="https://user-images.githubusercontent.com/6687910/100556420-348afe80-3257-11eb-9cac-387d22ad10ff.png">

Best
Norman

