### PR TITLE
Restore comaptibilty with skimage 0.19 & fix corruption determinism

### DIFF
--- a/imagecorruptions/__init__.py
+++ b/imagecorruptions/__init__.py
@@ -12,7 +12,7 @@ corruption_dict = {corr_func.__name__: corr_func for corr_func in
                    corruption_tuple}
 
 
-def corrupt(image, severity=1, corruption_name=None, corruption_number=-1):
+def corrupt(image, severity=1, corruption_name=None, corruption_number=-1, **kwargs):
     """This function returns a corrupted version of the given image.
 
     Args:
@@ -59,10 +59,10 @@ def corrupt(image, severity=1, corruption_name=None, corruption_number=-1):
 
     if not (corruption_name is None):
         image_corrupted = corruption_dict[corruption_name](Image.fromarray(image),
-                                                           severity)
+                                                           severity, **kwargs)
     elif corruption_number != -1:
         image_corrupted = corruption_tuple[corruption_number](Image.fromarray(image),
-                                                              severity)
+                                                              severity, **kwargs)
     else:
         raise ValueError("Either corruption_name or corruption_number must be passed")
 

--- a/imagecorruptions/corruptions.py
+++ b/imagecorruptions/corruptions.py
@@ -155,7 +155,9 @@ def _motion_blur(x, radius, sigma, angle):
 
 
 @njit()
-def _shuffle_pixels_njit_glass_blur(d0, d1, x, c):
+def _shuffle_pixels_njit_glass_blur(d0, d1, x, c, seed=None):
+
+    np.random.seed(seed)
 
     # locally shuffle pixels
     for i in range(c[2]):
@@ -211,7 +213,7 @@ def gaussian_blur(x, severity=1):
     x = gaussian(np.array(x) / 255., sigma=c, **kwargs)
     return np.clip(x, 0, 1) * 255
 
-def glass_blur(x, severity=1):
+def glass_blur(x, severity=1, seed=None):
     # sigma, max_delta, iterations
     c = [(0.7, 1, 2), (0.9, 2, 1), (1, 2, 3), (1.1, 3, 2), (1.5, 4, 2)][
         severity - 1]
@@ -224,7 +226,7 @@ def glass_blur(x, severity=1):
     x = np.uint8(
         gaussian(np.array(x) / 255., sigma=c[0], **kwargs) * 255)
 
-    x = _shuffle_pixels_njit_glass_blur(np.array(x).shape[0], np.array(x).shape[1], x, c)
+    x = _shuffle_pixels_njit_glass_blur(np.array(x).shape[0], np.array(x).shape[1], x, c, seed)
 
     return np.clip(gaussian(x / 255., sigma=c[0], **kwargs), 0,
                    1) * 255

--- a/imagecorruptions/corruptions.py
+++ b/imagecorruptions/corruptions.py
@@ -186,7 +186,7 @@ def shot_noise(x, severity=1):
     return np.clip(np.random.poisson(x * c) / float(c), 0, 1) * 255
 
 
-def impulse_noise(x, severity=1):
+def impulse_noise(x, severity=1, seed=None):
     c = [.03, .06, .09, 0.17, 0.27][severity - 1]
     mode = 's&p'
     x = sk.util.random_noise(np.array(x) / 255., 's&p', seed, amount=c)


### PR DESCRIPTION
Hi 👋 ,

thank you for providing `imagecorruptions` as open source package via github and via pypi!

I try to bring the (currently unmaintained) package [imgaug](https://github.com/aleju/imgaug) back to live. Fortunately the original maintainer provided an extensive collection of test cases I can run and check for breaking changes.

`imagecorruptions` is one of the dependencies which changed it's behavior in the recent years. Mostly due to changes in upstream libraries and recent commits to this github repository.

### supported scikit-image version

For a smooth transition between the (now 4 years old) `imgaug` 0.4.0 and an upcomming `0.4.1` I would like to support at `skimage` down to pre-0.19 times. Although the current master branch of `imagecorruptions` [claims](https://github.com/bethgelab/imagecorruptions/blob/3bab9d917b20118867f2977bd54bb0ba30aa74bb/setup.py#L24) to support `skimage` down to version >= 0.15 the recent commits 2393c1844812ac2b83e29d5b82c6377ad5f4921b and 6b18b822788922527e5e4113dfb0d2dc45230b90  broke that compatibility.

This pull request contains my suggestion on how to mitigate this depending on the installed `skimage` version. Since the fix is neither elegant nor pretty, I would suggest to introduce it as a temporary fix and drop the `scikit-image` compatibility for < 0.19 completely in upcoming releases of `imagecorruptions`.

### impulse_noise determinism for scikit-image >= 0.19

The later versions of `scikit-image` [use](https://github.com/scikit-image/scikit-image/pull/69229)  the "new" numpy random generator [interface](https://numpy.org/doc/1.21/reference/random/index.html#random-quick-start) in contrast to the legacy one. This comes with two implications for everyone who wants to create reproducible outputs with `imagecorruptions`:
* It is not sufficient to reset the global numpy random state (i.e. by reseeding outside the function call) for getting reproducible `impulse_noise` outputs
* If the `corrupt` function is used, the additional seed needs to be propagated to `impulse_noise` as keyword argument.

I made the corresponding changes. At least for the `imgaug` test cases this is sufficient to restore reproducibility.

### glass_blur determinism with njit

Commit 2393c1844812ac2b83e29d5b82c6377ad5f4921b introduces a speed up for `glass_blur` by using `numba` `jit`. The flip side for this speed-up is broken reproducibility. Numba provides [documentation](https://numba.readthedocs.io/en/stable/reference/pysupported.html#pysupported-random) on how to seed `numpy` random functions within a `njit`-decorated function.

I added the corresponding changes to this pull request.

Again: Thank you for providing `imagecorruptions` and I hope that my changes will be helpful for other `imagecorruption` users!

Best wishes,
Eric



