### PR TITLE
Bugfix: Package resources not available in python 3.12

### DIFF
--- a/imagecorruptions/__init__.py
+++ b/imagecorruptions/__init__.py
@@ -12,7 +12,7 @@ corruption_dict = {corr_func.__name__: corr_func for corr_func in
                    corruption_tuple}
 
 
-def corrupt(image, severity=1, corruption_name=None, corruption_number=-1):
+def corrupt(image, severity=1, corruption_name=None, corruption_number=-1, **kwargs):
     """This function returns a corrupted version of the given image.
 
     Args:
@@ -59,10 +59,10 @@ def corrupt(image, severity=1, corruption_name=None, corruption_number=-1):
 
     if not (corruption_name is None):
         image_corrupted = corruption_dict[corruption_name](Image.fromarray(image),
-                                                           severity)
+                                                           severity, **kwargs)
     elif corruption_number != -1:
         image_corrupted = corruption_tuple[corruption_number](Image.fromarray(image),
-                                                              severity)
+                                                              severity, **kwargs)
     else:
         raise ValueError("Either corruption_name or corruption_number must be passed")
 

--- a/imagecorruptions/corruptions.py
+++ b/imagecorruptions/corruptions.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 
-import os.path as path
-from importlib.resources import files
+try:
+    from importlib.resources import files
+except ImportError:
+    from pkg_resources import resource_filename as files
 
 import numpy as np
 import math
@@ -344,7 +346,7 @@ def frost(x, severity=1):
         './frost/frost6.jpg'
     ]
     
-    file_path = path.join(files(__name__), filenames[idx])
+    file_path = files(__name__, filenames[idx])
     frost = cv2.imread(file_path)
     frost_shape = frost.shape
     x_shape = np.array(x).shape

--- a/imagecorruptions/corruptions.py
+++ b/imagecorruptions/corruptions.py
@@ -155,7 +155,9 @@ def _motion_blur(x, radius, sigma, angle):
 
 
 @njit()
-def _shuffle_pixels_njit_glass_blur(d0, d1, x, c):
+def _shuffle_pixels_njit_glass_blur(d0, d1, x, c, seed=None):
+
+    np.random.seed(seed)
 
     # locally shuffle pixels
     for i in range(c[2]):
@@ -211,7 +213,7 @@ def gaussian_blur(x, severity=1):
     x = gaussian(np.array(x) / 255., sigma=c, **kwargs)
     return np.clip(x, 0, 1) * 255
 
-def glass_blur(x, severity=1):
+def glass_blur(x, severity=1, seed=None):
     # sigma, max_delta, iterations
     c = [(0.7, 1, 2), (0.9, 2, 1), (1, 2, 3), (1.1, 3, 2), (1.5, 4, 2)][
         severity - 1]
@@ -224,7 +226,7 @@ def glass_blur(x, severity=1):
     x = np.uint8(
         gaussian(np.array(x) / 255., sigma=c[0], **kwargs) * 255)
 
-    x = _shuffle_pixels_njit_glass_blur(np.array(x).shape[0], np.array(x).shape[1], x, c)
+    x = _shuffle_pixels_njit_glass_blur(np.array(x).shape[0], np.array(x).shape[1], x, c, seed)
 
     return np.clip(gaussian(x / 255., sigma=c[0], **kwargs), 0,
                    1) * 255

--- a/imagecorruptions/corruptions.py
+++ b/imagecorruptions/corruptions.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 
+import os.path as path
+from importlib.resources import files
+
 import numpy as np
 import math
 from PIL import Image
@@ -12,7 +15,6 @@ from io import BytesIO
 import cv2
 from scipy.ndimage import zoom as scizoom
 from scipy.ndimage.interpolation import map_coordinates
-from pkg_resources import resource_filename
 from numba import njit
 
 SK_VERSION = {k:int(v) for k,v in zip(['major', 'minor'], sk.__version__.split('.')[:2])}
@@ -331,14 +333,19 @@ def frost(x, severity=1):
          (0.65, 0.7),
          (0.6, 0.75)][severity - 1]
 
-    idx = np.random.randint(5)
-    filename = [resource_filename(__name__, './frost/frost1.png'),
-                resource_filename(__name__, './frost/frost2.png'),
-                resource_filename(__name__, './frost/frost3.png'),
-                resource_filename(__name__, './frost/frost4.jpg'),
-                resource_filename(__name__, './frost/frost5.jpg'),
-                resource_filename(__name__, './frost/frost6.jpg')][idx]
-    frost = cv2.imread(filename)
+    idx = np.random.randint(6)
+
+    filenames = [
+        './frost/frost1.png',
+        './frost/frost2.png',
+        './frost/frost3.png', 
+        './frost/frost4.jpg',
+        './frost/frost5.jpg',
+        './frost/frost6.jpg'
+    ]
+    
+    file_path = path.join(files(__name__), filenames[idx])
+    frost = cv2.imread(file_path)
     frost_shape = frost.shape
     x_shape = np.array(x).shape
 

--- a/imagecorruptions/corruptions.py
+++ b/imagecorruptions/corruptions.py
@@ -186,7 +186,7 @@ def shot_noise(x, severity=1):
     return np.clip(np.random.poisson(x * c) / float(c), 0, 1) * 255
 
 
-def impulse_noise(x, severity=1):
+def impulse_noise(x, severity=1, seed=None):
     c = [.03, .06, .09, 0.17, 0.27][severity - 1]
     mode = 's&p'
     x = sk.util.random_noise(np.array(x) / 255., 's&p', seed, amount=c)

--- a/imagecorruptions/corruptions.py
+++ b/imagecorruptions/corruptions.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
 
 try:
+    import os.path as path
     from importlib.resources import files
+    def resource_filename(anchor, resources):
+        return path.join(files(anchor), resources)
 except ImportError:
-    from pkg_resources import resource_filename as files
+    from pkg_resources import resource_filename
 
 import numpy as np
 import math
@@ -346,7 +349,7 @@ def frost(x, severity=1):
         './frost/frost6.jpg'
     ]
     
-    file_path = files(__name__, filenames[idx])
+    file_path = resource_filename(__name__, filenames[idx])
     frost = cv2.imread(file_path)
     frost_shape = frost.shape
     x_shape = np.array(x).shape


### PR DESCRIPTION
Hi,

this is an add-on pull request to #27 .

Python >= 3.12 does not come with [bundled setuptools](https://github.com/python/cpython/issues/95299) anymore. Using `imagecorruptions` therefore results in an error messages without a manual `setuptools` installation.

Additionally, `pkg_resources` is marked as [depreciated](https://setuptools.pypa.io/en/latest/pkg_resources.html) by `setuptools` itself and the project recommends using `importlib` functionality instead.

This pull request fixes the missing module error on Python 3.12 and fixes a bug with respect to the `numpy.random.randint` call in the `frost` function.

Best wishes,
Eric


